### PR TITLE
Correct the description of when you can access and mutate state prope…

### DIFF
--- a/SwiftUI.swift
+++ b/SwiftUI.swift
@@ -29395,8 +29395,8 @@ public struct StackNavigationViewStyle : NavigationViewStyle {
 /// Note:
 ///
 /// - `changeText` is not a `mutating ` function. This is because the `@State` property wrapper internally uses a reference based storage managed by the SwiftUI runtime.
-/// - Accessing a state property is only valid when done form inside the view's body property or code called from the view's body property.
-/// - Because state properties should only be accessed from the body it's good practice to declare them as private.
+/// - Only access a state property from inside the view’s body, or from methods called by it.
+/// - Declare state properties as private, to prevent outside code from accessing them.
 /// - Although you should only access the state from inside the body, you can mutate it elsewhere including from any thread.
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 @frozen @propertyWrapper public struct State<Value> : DynamicProperty {

--- a/SwiftUI.swift
+++ b/SwiftUI.swift
@@ -29395,7 +29395,9 @@ public struct StackNavigationViewStyle : NavigationViewStyle {
 /// Note:
 ///
 /// - `changeText` is not a `mutating ` function. This is because the `@State` property wrapper internally uses a reference based storage managed by the SwiftUI runtime.
-/// - All modifications to a state variable **must** happen on the main thread. Modifying a state variable on a background thread may lead to undefined behavior.
+/// - Accessing a state property is only valid when done form inside the view's body property or code called from the view's body property.
+/// - Because state properties should only be accessed from the body it's good practice to declare them as private.
+/// - Although you should only access the state from inside the body, you can mutate it elsewhere including from any thread.
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 @frozen @propertyWrapper public struct State<Value> : DynamicProperty {
 


### PR DESCRIPTION
…rties to align with what's in Apple's official documentation.

This is what it says in Apples documentation for `@frozen @propertyWrapper struct State<Value>`
> You should only access a state property from inside the view’s body, or from methods called by it. For this reason, declare your state properties as private, to prevent clients of your view from accessing them. It is safe to mutate state properties from any thread.

I tried to rephrase the wording in Apples documentation as not to plagiarize, but I since Apple's documentation is already very concise, I feel like I just added fluff to something that was already clear. I'm open to suggestions regarding rephrasing.

This edit should clarify two points:
1. Accessing a state property is actually more strict than using the main thread. It should only be accessed from the call to the view's body.
2. Modifying state is actually completely permissive and can be accessed from any thread.

