### PR TITLE
Update pipeline to deprecate develop branch

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -2,8 +2,8 @@ name: Push to S3 bucket
 
 on:
   push:
-    branches:
-    - main
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -3,7 +3,7 @@ name: Push to S3 bucket
 on:
   push:
     branches:
-    - develop
+      - main
 
 jobs:
   deploy:


### PR DESCRIPTION
The current CICD pipeline deploys to QA when a branch is merged into develop, and it deploys to production when you merge into main. This can create confusion about what branch to push to, along with increased friction with ensuring the develop/main branches stay in-sync. 

This PR updates the pipeline so that a merge into main deploys to QA and a new semantic versioned tag deploys to production.